### PR TITLE
Support incsearch

### DIFF
--- a/autoload/peculiar.vim
+++ b/autoload/peculiar.vim
@@ -2,72 +2,69 @@ function! peculiar#lines(...) abort
   return line("'[") . "," . line("']")
 endfunction
 
-let s:last_command=""
-let s:last_modifier_string=""
-let s:last_search=""
+let s:max_depth = 100
+function! peculiar#last_norm_command() abort
+  for current_depth in range(s:max_depth)
+    let current_value = histget(":", -current_depth)
+    if match(current_value, "norm") != -1
+      return current_value
+    endif
+  endfor
+
+  throw "No recent norm command found!"
+endfunction
 
 function! peculiar#repeat(...) abort
   if !a:0
     let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
     return 'g@'
+  else
+    let lines = peculiar#lines(a:0, a:1) 
+    let cmd = peculiar#last_norm_command()
+    execute substitute(cmd, '[0-9]\+,[0-9]\+', lines, "")
   endif
-  let lines = peculiar#lines(a:0, a:1)
-  let to_execute = lines . s:last_modifier_string . s:last_search
-  if s:last_modifier_string != ""
-    let to_execute = to_execute . "/"
-  endif
-  exec to_execute . "norm " . s:last_command
 endfunction
 
-function! peculiar#run_peculiar(lines, modifier_string, search) abort
-  let prompt = a:lines . a:modifier_string . a:search
-  if a:modifier_string != ""
-    let prompt = prompt . "/"
+let s:should_prompt=0
+function! peculiar#prompt() abort
+  let cmd = histget(":")
+  call histdel(":", -1)
+  if s:should_prompt
+    call feedkeys(":" . cmd . repeat("\<BS>", 22) . "norm ")
+    let s:should_prompt=0
   endif
-  let prompt = prompt . "norm "
-  let command = input("Run: " . prompt)
-  let s:last_command = command
-  let s:last_modifier_string = a:modifier_string
-  let s:last_search = a:search
-  let to_execute = prompt . command
-  call histadd("cmd", to_execute)
-  exec to_execute
 endfunction
 
-function! peculiar#g_object(...) abort
+function! peculiar#v(...) abort
+  if !a:0
+    let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
+    return 'g@'
+  else
+    let s:should_prompt=1
+    let lines = peculiar#lines(a:0, a:1) 
+    call feedkeys(":" . lines . "v//call peculiar#prompt()" . repeat("\<Left>", 23))
+  endif
+endfunction
+
+function! peculiar#n(...) abort
   if !a:0
     let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
     return 'g@'
   else
     let lines = peculiar#lines(a:0, a:1) 
-    let search = input("Run (Leave empty for last search): g/\\v")
-    if search == ""
-      let search = @/
-    endif
-    call peculiar#run_peculiar(lines, "g/\\v", search)
+    let s:should_prompt=1
+    call histadd(":", "keeppatterns " . lines . "g/\\v.*/call peculiar#prompt()")
+    call peculiar#prompt()
   endif
 endfunction
 
-function! peculiar#v_object(...) abort
+function! peculiar#g(...) abort
   if !a:0
     let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
     return 'g@'
   else
+    let s:should_prompt=1
     let lines = peculiar#lines(a:0, a:1) 
-    let search = input("Run (Leave empty for last search): v/\\v")
-    if search == ""
-      let search = @/
-    endif
-    call peculiar#run_peculiar(lines, "v/\\v", search)
-  endif
-endfunction
-
-function! peculiar#n_object(...) abort
-  if !a:0
-    let &operatorfunc = matchstr(expand('<sfile>'), '[^. ]*$')
-    return 'g@'
-  else
-    let lines = peculiar#lines(a:0, a:1) 
-    call peculiar#run_peculiar("keeppatterns " . lines, "g/\\v", ".*")
+    call feedkeys(":" . lines . "g//call peculiar#prompt()" . repeat("\<Left>", 23))
   endif
 endfunction

--- a/plugin/vim-peculiar.vim
+++ b/plugin/vim-peculiar.vim
@@ -1,4 +1,4 @@
-nnoremap <expr> <Plug>PeculiarN peculiar#n_object()
-nnoremap <expr> <Plug>PeculiarG peculiar#g_object()
-nnoremap <expr> <Plug>PeculiarV peculiar#v_object()
+nnoremap <expr> <Plug>PeculiarN peculiar#n()
+nnoremap <expr> <Plug>PeculiarG peculiar#g()
+nnoremap <expr> <Plug>PeculiarV peculiar#v()
 nnoremap <expr> <Plug>PeculiarR peculiar#repeat()


### PR DESCRIPTION
**Why** is the change needed?

So that it's a lot more clear lines you are hitting with PeculiarG and
PeculiarV.

**How** is the need addressed?

-   Keep the key-presses the same
-   Rely on command line functions and `feedkeys` instead of `input`

What **side-effects** could the change have?

-   PeculiarN now lights up the matched selection as well. Is this
    a good thing?
- The prompt looks different

Closes #5