### PR TITLE
Add flag for suppressing incsearch for PeculiarN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ nmap <localleader>r <Plug>PeculiarR
 Each command run updates the command line history and the search commands update
 the search history for easy editing if you make mistakes.
 
+## Options
+
+The normal command used in `PeculiarN` will cause the whole selection to be
+highlighted if `incsearch` is turned on. If you want to run `PeculiarN` in
+a function instead (thus suppressing the highlight), you can set.
+
+```vim
+let g:peculiar#surpress_highlight_n = 1
+```
+
 ## Attributions
 
 - The first version of this plugin was heavily inspired by

--- a/autoload/peculiar.vim
+++ b/autoload/peculiar.vim
@@ -2,6 +2,10 @@ function! peculiar#lines(...) abort
   return line("'[") . "," . line("']")
 endfunction
 
+if !exists("g:peculiar#suppress_highlight_n")
+    let g:peculiar#suppress_highlight_n = 0    
+endif
+
 let s:max_depth = 100
 function! peculiar#last_norm_command() abort
   for current_depth in range(s:max_depth)
@@ -53,8 +57,15 @@ function! peculiar#n(...) abort
   else
     let lines = peculiar#lines(a:0, a:1) 
     let s:should_prompt=1
-    call histadd(":", "keeppatterns " . lines . "g/\\v.*/call peculiar#prompt()")
-    call peculiar#prompt()
+    if g:peculiar#suppress_highlight_n == 1
+        let prompt = "keeppatterns " . lines . "g/\\v.*/norm "
+        let n_cmd = input("Run :" . prompt, "")
+        call histadd(":", prompt . n_cmd)
+        execute prompt . n_cmd
+    else
+        call histadd(":", "keeppatterns " . lines . "g/\\v.*/call peculiar#prompt()")
+        call peculiar#prompt()
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
**Why** is the change needed?

As a part of #6 the peculiar commands were reworked as command-line
functions instead of using input, in order to support incremental
search.

One side effect is that PeculiarN shows the whole search as matching.
Put it behind a flag, since it's unclear whether this is preferred over
the previous implementation.

**How** is the need addressed?

- Add a flag called `g:peculiar#suppress_highlight_n`
- Use the old implementation if the flag is set.

Closes #7